### PR TITLE
Atomic cpu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,8 @@ gem5/dockerfiles/slurm*
 
 slurm-docker-cluster/slurm*
 docker-compose.yml
+
+*.png
+*.pdf
+*.csv
+*.tar.gz

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "RING-5"]
+	path = RING-5
+	url = https://github.com/nikiitin/RING-5/tree/MICRO24-521

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "RING-5"]
 	path = RING-5
-	url = https://github.com/nikiitin/RING-5/tree/MICRO24-521
+	url = https://github.com/nikiitin/RING-5.git

--- a/Makefile
+++ b/Makefile
@@ -223,7 +223,7 @@ run:
 
 stop:
 	@echo "Stopping the containers..."
-	@sudo docker compose down
+	@sudo docker compose down --volumes
 	@echo "Containers stopped!"
 
 connect:

--- a/Makefile
+++ b/Makefile
@@ -187,8 +187,10 @@ configure_dependencies_gem5:
 	@echo "gem5 dependencies installed!"
 ### END CONTAINER CONFIGURATION ###
 
+build_RING-5:
+	@cd RING-5 && make build
 
-build: check_kvm_environment check_docker_environment configure_containers configure_dependencies_gem5
+build: check_kvm_environment check_docker_environment configure_containers configure_dependencies_gem5 build_RING-5
 	@echo "Building all the containers from the compose file..."
 	@echo "This may take a while and a lot of disk space..."
 	@echo "Additionally, it requires sudo permissions."
@@ -229,3 +231,6 @@ clean:
 	@echo "To totally clean the environment, I'd suggest to remove everything from /var/lib/docker directory."
 	@echo "Cleaning cached data..."
 	rm -rf gem5/dependencies
+
+plot:
+	@cd RING-5 && make run

--- a/Makefile
+++ b/Makefile
@@ -193,7 +193,7 @@ add_submodules:
 checkout_RING-5_branch:
 	@cd RING-5 && git checkout MICRO24
 
-build_RING-5: add_submodules
+build_RING-5: add_submodules checkout_RING-5_branch
 	@cd RING-5 && make build
 
 build: check_kvm_environment check_docker_environment configure_containers configure_dependencies_gem5 build_RING-5

--- a/Makefile
+++ b/Makefile
@@ -187,7 +187,13 @@ configure_dependencies_gem5:
 	@echo "gem5 dependencies installed!"
 ### END CONTAINER CONFIGURATION ###
 
-build_RING-5:
+add_submodules:
+	@git submodule update --init --recursive
+
+checkout_RING-5_branch:
+	@cd RING-5 && git checkout MICRO24
+
+build_RING-5: add_submodules
 	@cd RING-5 && make build
 
 build: check_kvm_environment check_docker_environment configure_containers configure_dependencies_gem5 build_RING-5

--- a/Makefile
+++ b/Makefile
@@ -211,7 +211,7 @@ build: check_kvm_environment check_docker_environment configure_containers confi
 		"gem5 uses KVM to run the simulations with fast-forward." \
 		"all the containers will try to use /dev/kvm device from this host."
 
-build: BUILD_TYPE_VIRT = atomic
+build_atomic: BUILD_TYPE_VIRT = atomic
 build_atomic: check_docker_environment configure_containers configure_dependencies_gem5 build_RING-5
 	@echo "Building all the containers from the compose file..."
 	@echo "This may take a while and a lot of disk space..."

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,6 @@
 DOCKER_ENGINE_VERSION = 27.1.1
 DOCKER_COMPOSE_VERSION = 2.29.1
 CONTAINERD_VERSION = 1.7.19
-# Will the build use kvm?
-# By default, NO
-BUILD_TYPE_VIRT = atomic
 # Maximum memory per container in kbytes
 # Set to 3.5GiB by default
 # Should not expect to spend more than 3.5GiB to execute
@@ -39,7 +36,6 @@ export M_NUM_SERVICES
 ### KVM ENVIROMENT ###
 check_kvm_environment: kvm_check reduce_paranoid
 	@echo "KVM environment is ready!"
-	BUILD_TYPE_VIRT = kvm
 
 kvm_check: 
 # Check if KVM is installed
@@ -203,6 +199,7 @@ build_RING-5: add_submodules checkout_RING-5_branch
 ### END SUBMODULES ###
 
 ### Objectives for the user ###
+build: BUILD_TYPE_VIRT = kvm
 build: check_kvm_environment check_docker_environment configure_containers configure_dependencies_gem5 build_RING-5
 	@echo "Building all the containers from the compose file..."
 	@echo "This may take a while and a lot of disk space..."
@@ -214,6 +211,7 @@ build: check_kvm_environment check_docker_environment configure_containers confi
 		"gem5 uses KVM to run the simulations with fast-forward." \
 		"all the containers will try to use /dev/kvm device from this host."
 
+build: BUILD_TYPE_VIRT = atomic
 build_atomic: check_docker_environment configure_containers configure_dependencies_gem5 build_RING-5
 	@echo "Building all the containers from the compose file..."
 	@echo "This may take a while and a lot of disk space..."

--- a/Readme.md
+++ b/Readme.md
@@ -3,11 +3,13 @@ In this document we explain how to install and deploy containers for MICRO submi
 
 ## Requirements
 - KVM must be enabled in your machine.
-- Docker ver. 27.1.1
-- Docker compose ver. 2.29.1
+- Docker ver. 27.1.1 (Will be installed with build)
+- Docker compose ver. 2.29.1 (Will be installed with build)
 - Ubuntu (for this experiments ver. 20.04 LTS was used)
+- Python ver. 3.8.10
 - Virtualization support (Check in your BIOS)
-- R ver. 4.4.1
+- R ver. 4.4.1 ([instructions to install](https://cran.r-project.org/bin/linux/ubuntu/fullREADME.html))
+- perl 4.4 ([instructions to install](https://ultahost.com/knowledge-base/install-perl-ubuntu/))
 For ease of use and reduced reproducibility complexity, we provided the user with a make file that is automated to easily install almost all these tools.
 
 ## Deploy steps

--- a/Readme.md
+++ b/Readme.md
@@ -7,12 +7,12 @@ In this document we explain how to install and deploy containers for MICRO submi
 - Docker compose ver. 2.29.1
 - Ubuntu (for this experiments ver. 20.04 LTS was used)
 - Virtualization support (Check in your BIOS)
+- R ver. 4.4.1
 For ease of use and reduced reproducibility complexity, we provided the user with a make file that is automated to easily install almost all these tools.
 
 ## Deploy steps
-1. Change to containers directory. Execute make build to prepare all the configurations and containers. This step can take a while since the simulator is big and it will need to build from scratch. Additionally, root permission will be required since it will have to install several dependencies, reduce perf paranoid from kernel, use docker, etc.
+1. Execute make build at the root of the repository to prepare all the configurations and containers. This step can take a while since the simulator is big and it will need to build from scratch. Additionally, root permission will be required since it will have to install several dependencies, reduce perf paranoid from kernel, use docker, etc.
 ~~~bash
-cd containers
 sudo make build
 ~~~
 2. Once the application is fully built, it will prompt with the message "Everything built correctly!". Additionally, will print some notes that the user should carefully read. It is now time to run the containers. One objective is prepared to compose and run all of them. While building, the application automatically resolved how many containers would create depending on your system specifications. Again, as docker is being run, use sudo.
@@ -57,3 +57,10 @@ systemctl stop docker
 rm -rf /var/lib/docker
 systemctl start docker
 ~~~
+## Getting the results
+To obtain the results we used [RING-5](https://github.com/nikiitin/RING-5.git) which is a R-based statistical analysis tool for gem5. Note that even if it is public it is an experimental tool and is prone to failure. We pushed a specific branch (MICRO24) that will be kept to keep reproducibility. This tool will be built and configured altogether with the previous ```make build``` command.
+Once all the simulations are finished, you can execute the following command that will execute RING-5 with the configurations for this project:
+~~~bash
+make plot
+~~~
+It will try to execute RING-5 for all the stats files found at ```results``` folder. It will create several folders, each containing the results of the experiments, both in csv and in graphic format with png files and each corresponding to the figure in the original manuscript.

--- a/Readme.md
+++ b/Readme.md
@@ -2,7 +2,7 @@
 In this document we explain how to install and deploy containers for MICRO submission 521 Chaining Transactions for Effective Concurrency Management in Hardware Transactional Memory. This application contains the gem5 simulator used for the experiments, a linux image with the benchmark binaries and inputs, scripts prepared to reproduce the results and to analyze the data.
 
 ## Requirements
-- KVM must be enabled in your machine.
+- KVM is encouraged to be enabled in your machine.
 - Docker ver. 27.1.1 (Will be installed with build)
 - Docker compose ver. 2.29.1 (Will be installed with build)
 - Ubuntu (for this experiments ver. 20.04 LTS was used)
@@ -11,11 +11,16 @@ In this document we explain how to install and deploy containers for MICRO submi
 - R ver. 4.4.1 ([instructions to install](https://cran.r-project.org/bin/linux/ubuntu/fullREADME.html))
 - perl 4.4 ([instructions to install](https://ultahost.com/knowledge-base/install-perl-ubuntu/))
 For ease of use and reduced reproducibility complexity, we provided the user with a make file that is automated to easily install almost all these tools.
+R and perl will not be installed, so, please, follow the instructions in the links provided.
 
 ## Deploy steps
 1. Execute make build at the root of the repository to prepare all the configurations and containers. This step can take a while since the simulator is big and it will need to build from scratch. Additionally, root permission will be required since it will have to install several dependencies, reduce perf paranoid from kernel, use docker, etc.
 ~~~bash
 sudo make build
+~~~
+In case the user do not have KVM enabled, it can prompt with several errors, build can fail and if not, simulations will not work. For those cases, fast-forward can be done with atomicSimpleCPU instead of KVM. Note that simulations will take much more time to finish, hence, we encourage the use of KVM if possible. To build the atomicCPU version use the following command:
+~~~bash
+sudo make build_atomic
 ~~~
 2. Once the application is fully built, it will prompt with the message "Everything built correctly!". Additionally, will print some notes that the user should carefully read. It is now time to run the containers. One objective is prepared to compose and run all of them. While building, the application automatically resolved how many containers would create depending on your system specifications. Again, as docker is being run, use sudo.
 ~~~bash
@@ -30,8 +35,9 @@ sudo make connect
 Inside the gem5 folder, there is a directory called gem5_path that contains all required to run full-system simulations and some scripts that can help the user in many use cases. We created a folder with all the scripts that submit the simulations that give the results shown in the paper. To replicate, for example, the results from the main figures, you can execute the following commands:
 ~~~bash
 cd /gem5/gem5_path/scripts/2023-02.valuepred/
-./generate-simulations-main --enqueue
+./generate-simulations-main --enqueue [-k]
 ~~~
+Note the option ```-k``` which is optional. This option MUST be used in case KVM is not enabled, to run the simulations with atomicSimpleCPU. Else, by default it will use KVM to fast-forward.
 This command will generate a bunch of folders containing the simulation scripts that are executed in batches by slurm. You will be able to find the results from the execution in stats.txt file, along with the simulation configuration used. For example, once the simulation finishes, you can perform the next operations to access the stats file:
 ~~~bash
 cd /gem5/results/valuepred-main/CPUtest_BinSfx.htm.fallbacklock_LV_ED_CRrw_RSL0Ev_RSPrec_L0Repl_L1Repl_RldStale_DwnG_Rtry6_Pflt/stamp.genome/0
@@ -66,3 +72,20 @@ Once all the simulations are finished, you can execute the following command tha
 make plot
 ~~~
 It will try to execute RING-5 for all the stats files found at ```results``` folder. It will create several folders, each containing the results of the experiments, both in csv and in graphic format with png files and each corresponding to the figure in the original manuscript.
+
+## Dependencies
+Please, check the links aforementioned for installing R and perl. Dependencies for docker and docker compose will be downloaded in the build process. Additionally, some dependencies will be required to download from [this url](https://univmurcia-my.sharepoint.com/:u:/g/personal/victor_nicolasc_um_es/EZ4ZYu33sepFsx3oHpQhw2ABQ1OHGb4ZQ8jT77JXG-Objg?e=Tqv8UA&download=1) for gem5 to run. Those will be installed with the ```configure_dependencies_gem5``` rule for make. This one is called from within the main makefile, but in case it does not work, you can just retry to run the rule with:
+~~~bash
+make configure_dependencies_gem5
+~~~
+Dependencies for R and python packages from RING-5 should be automatically solved too with build process as it uses renv to locally manage them. If build process could not finish the dependency download, you can execute the following commands:
+~~~R
+# In the root folder from RING-5 repository
+R
+renv::activate()
+q()
+R
+renv::restore()
+q()
+~~~
+This should activate the dependency manager and download all the required packages from R.

--- a/gem5/Dockerfile
+++ b/gem5/Dockerfile
@@ -30,7 +30,6 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt -y update && apt -y upgrade && \
         apt -y install \
         build-essential \
-        git \
         m4 \
         scons \
         zlib1g \
@@ -39,7 +38,6 @@ RUN apt -y update && apt -y upgrade && \
         protobuf-compiler \
         libprotoc-dev \
         libgoogle-perftools-dev \
-        python3-dev \
         python-is-python3 \
         doxygen \
         libboost-all-dev \

--- a/gem5/Makefile
+++ b/gem5/Makefile
@@ -51,5 +51,5 @@ unpack_modules:
 
 install_dependencies:
 	@echo "Installing dependencies for gem5..."
-	@rsync "$(GEM5_DEPENDENCIES_PATH)/gem5_path/" "./gem5_path/"
+	rsync -r "$(GEM5_DEPENDENCIES_PATH)/gem5_path/" "./gem5_path/"
 	@echo "Dependencies installed!"

--- a/gem5/gem5_path/scripts/CHATS/config.chats.blocks.sensibility.py
+++ b/gem5/gem5_path/scripts/CHATS/config.chats.blocks.sensibility.py
@@ -4,6 +4,7 @@
 from gem5_run import configs_set, configs_update, configs_vary, Vary, get_benchmarks, update
 from options import *
 import templates
+import os
 
 configs_set(templates.base)
 configs_update(templates.cache_alder_lake_new)
@@ -15,6 +16,11 @@ configs_vary(
 )
 configs_vary(
              {cpu_model: "DerivO3CPU"},
+)
+kvm_enabled = os.getenv("KVM_ACTIVE", "False")
+kvm_enabled = True if kvm_enabled.lower() == "true" else False
+configs_vary(
+    {enable_kvm: kvm_enabled},
 )
 configs_vary(
     {work_warmup_active: False}
@@ -80,7 +86,6 @@ configs_update({
     random_seed: Vary(*range(3)),
 })
 
-import os
 output_dir = os.getenv("OUTPUT_DIR")
 if output_dir != None and output_dir != "":
     configs_update({ output_directory_base: os.path.realpath(output_dir) })

--- a/gem5/gem5_path/scripts/CHATS/config.chats.fwdrvsfwdw.py
+++ b/gem5/gem5_path/scripts/CHATS/config.chats.fwdrvsfwdw.py
@@ -16,6 +16,11 @@ configs_vary(
 configs_vary(
              {cpu_model: "DerivO3CPU"},
 )
+kvm_enabled = os.getenv("KVM_ACTIVE", "False")
+kvm_enabled = True if kvm_enabled.lower() == "true" else False
+configs_vary(
+    {enable_kvm: kvm_enabled},
+)
 configs_vary(
     {work_warmup_active: False}
 )

--- a/gem5/gem5_path/scripts/CHATS/config.chats.fwdrvsfwdw.py
+++ b/gem5/gem5_path/scripts/CHATS/config.chats.fwdrvsfwdw.py
@@ -4,7 +4,7 @@
 from gem5_run import configs_set, configs_update, configs_vary, Vary, get_benchmarks, update
 from options import *
 import templates
-
+import os
 configs_set(templates.base)
 configs_update(templates.model_final)
 #configs_update({num_cpus: 4})
@@ -87,7 +87,6 @@ configs_update({
     random_seed: Vary(*range(3)),
 })
 
-import os
 output_dir = os.getenv("OUTPUT_DIR")
 if output_dir != None and output_dir != "":
     configs_update({ output_directory_base: os.path.realpath(output_dir) })

--- a/gem5/gem5_path/scripts/CHATS/config.chats.main.py
+++ b/gem5/gem5_path/scripts/CHATS/config.chats.main.py
@@ -13,6 +13,11 @@ configs_vary(
     update(templates.htm_cfg2_l0rsetevict, { num_cpus: Vary(16) }),
 )
 configs_vary({cpu_model: "DerivO3CPU"},)
+kvm_enabled = os.getenv("KVM_ACTIVE", "False")
+kvm_enabled = True if kvm_enabled.lower() == "true" else False
+configs_vary(
+    {enable_kvm: kvm_enabled},
+)
 configs_vary(
     {work_warmup_active: False}
 )

--- a/gem5/gem5_path/scripts/CHATS/config.chats.main.py
+++ b/gem5/gem5_path/scripts/CHATS/config.chats.main.py
@@ -4,6 +4,7 @@
 from gem5_run import configs_set, configs_update, configs_vary, Vary, get_benchmarks, update
 from options import *
 import templates
+import os
 
 configs_set(templates.base)
 configs_update(templates.model_final)
@@ -111,7 +112,6 @@ configs_update({
     random_seed: Vary(*range(3)),
 })
 
-import os
 output_dir = os.getenv("OUTPUT_DIR")
 if output_dir != None and output_dir != "":
     configs_update({ output_directory_base: os.path.realpath(output_dir) })

--- a/gem5/gem5_path/scripts/CHATS/config.valuepred.retry.sensibility.py
+++ b/gem5/gem5_path/scripts/CHATS/config.valuepred.retry.sensibility.py
@@ -4,7 +4,7 @@
 from gem5_run import configs_set, configs_update, configs_vary, Vary, get_benchmarks, update
 from options import *
 import templates
-
+import os
 configs_set(templates.base)
 configs_update(templates.model_final)
 configs_update(templates.htm_cfg2_l0rsetevict)
@@ -100,7 +100,6 @@ configs_update({
     random_seed: Vary(*range(3)),
 })
 
-import os
 output_dir = os.getenv("OUTPUT_DIR")
 if output_dir != None and output_dir != "":
     configs_update({ output_directory_base: os.path.realpath(output_dir) })

--- a/gem5/gem5_path/scripts/CHATS/config.valuepred.retry.sensibility.py
+++ b/gem5/gem5_path/scripts/CHATS/config.valuepred.retry.sensibility.py
@@ -15,6 +15,11 @@ configs_vary(
 configs_vary(
              {cpu_model: "DerivO3CPU"},
 )
+kvm_enabled = os.getenv("KVM_ACTIVE", "False")
+kvm_enabled = True if kvm_enabled.lower() == "true" else False
+configs_vary(
+    {enable_kvm: kvm_enabled},
+)
 configs_vary(
     {work_warmup_active: False}
 )

--- a/gem5/gem5_path/scripts/CHATS/generate-simulations-blocks-sens
+++ b/gem5/gem5_path/scripts/CHATS/generate-simulations-blocks-sens
@@ -1,4 +1,11 @@
 #!/bin/bash
+usage () {
+    echo "Usage: $0 [-k] [-q|--enqueue]"
+    echo
+    echo "Options:"
+    echo "  -k: Use KVM for the simulations."
+    echo "  -q, --enqueue: Enqueue the generated simulations to slurm."
+}
 
 SCRIPT_DIR="$(dirname "$(realpath "$0")")"
 SCRIPT_COMMAND="$0"
@@ -13,14 +20,34 @@ CONFIG_FILE="$SCRIPT_DIR/config.chats.blocks.sensibility.py"
 GEN_SCRIPTS="$SCRIPT_DIR/../run-scripts/gem5_gen_scripts.py" 
 GEN_SCRIPTS_ARGS=("--config-file" "$CONFIG_FILE")
 
-if [[ "$#" = 1 && ( "$1" = "-q" || "$1" = "--enqueue" )]] ; then
-    GEN_SCRIPTS_ARGS=("${GEN_SCRIPTS_ARGS[@]}" "--enqueue" )
-elif [[ "$#" = 0 ]] ; then
-    : # only generate
-else
-    echo "Only argument supported is -q or --enqueue to enqueue."
-    exit 1
-fi
+while getopts "kq-:" opt; do
+    case "$opt" in
+        -)
+            case "${OPTARG}" in
+                enqueue)
+                    GEN_SCRIPTS_ARGS=("${GEN_SCRIPTS_ARGS[@]}" "--enqueue" )
+                    ;;
+                *)
+                    echo "Invalid option: --$OPTARG" >&2
+                    usage
+                    exit 1
+                    ;;
+            esac
+            ;;
+        q)
+            GEN_SCRIPTS_ARGS=("${GEN_SCRIPTS_ARGS[@]}" "--enqueue" )
+            ;;
+        k)
+            export KVM_ACTIVE="true"
+            ;;
+        *)
+            echo "Invalid option: -$OPTARG" >&2
+            usage
+            exit 1
+            ;;
+    esac
+done
+
 
 # This environment variable is used by $CONFIG_FILE
 export OUTPUT_DIR="${OUTPUT_DIR:-$(realpath "$SCRIPT_DIR/../../../results/chats-blocks-sens")}"
@@ -31,4 +58,4 @@ export OUTPUT_DIR="${OUTPUT_DIR:-$(realpath "$SCRIPT_DIR/../../../results/chats-
     exit 1;
 }
 
-"$GEN_SCRIPTS" "${GEN_SCRIPTS_ARGS[@]}" "$@"
+"$GEN_SCRIPTS" "${GEN_SCRIPTS_ARGS[@]}"

--- a/gem5/gem5_path/scripts/CHATS/generate-simulations-blocks-sens
+++ b/gem5/gem5_path/scripts/CHATS/generate-simulations-blocks-sens
@@ -3,7 +3,7 @@ usage () {
     echo "Usage: $0 [-k] [-q|--enqueue]"
     echo
     echo "Options:"
-    echo "  -k: Use KVM for the simulations."
+    echo "  -k: Do NOT use KVM for the simulations."
     echo "  -q, --enqueue: Enqueue the generated simulations to slurm."
 }
 
@@ -19,7 +19,7 @@ CONFIG_FILE="$SCRIPT_DIR/config.chats.blocks.sensibility.py"
 
 GEN_SCRIPTS="$SCRIPT_DIR/../run-scripts/gem5_gen_scripts.py" 
 GEN_SCRIPTS_ARGS=("--config-file" "$CONFIG_FILE")
-export KVM_ACTIVE="false"
+export KVM_ACTIVE="true"
 while getopts "kq-:" opt; do
     case "$opt" in
         -)
@@ -38,7 +38,7 @@ while getopts "kq-:" opt; do
             GEN_SCRIPTS_ARGS=("${GEN_SCRIPTS_ARGS[@]}" "--enqueue" )
             ;;
         k)
-            export KVM_ACTIVE="true"
+            export KVM_ACTIVE="false"
             ;;
         *)
             echo "Invalid option: -$OPTARG" >&2

--- a/gem5/gem5_path/scripts/CHATS/generate-simulations-blocks-sens
+++ b/gem5/gem5_path/scripts/CHATS/generate-simulations-blocks-sens
@@ -19,7 +19,7 @@ CONFIG_FILE="$SCRIPT_DIR/config.chats.blocks.sensibility.py"
 
 GEN_SCRIPTS="$SCRIPT_DIR/../run-scripts/gem5_gen_scripts.py" 
 GEN_SCRIPTS_ARGS=("--config-file" "$CONFIG_FILE")
-
+export KVM_ACTIVE="false"
 while getopts "kq-:" opt; do
     case "$opt" in
         -)

--- a/gem5/gem5_path/scripts/CHATS/generate-simulations-fwdrvsfwdw
+++ b/gem5/gem5_path/scripts/CHATS/generate-simulations-fwdrvsfwdw
@@ -19,7 +19,7 @@ CONFIG_FILE="$SCRIPT_DIR/config.chats.fwdrvsfwdw.py"
 
 GEN_SCRIPTS="$SCRIPT_DIR/../run-scripts/gem5_gen_scripts.py" 
 GEN_SCRIPTS_ARGS=("--config-file" "$CONFIG_FILE")
-
+export KVM_ACTIVE="false"
 while getopts "kq-:" opt; do
     case "$opt" in
         -)

--- a/gem5/gem5_path/scripts/CHATS/generate-simulations-fwdrvsfwdw
+++ b/gem5/gem5_path/scripts/CHATS/generate-simulations-fwdrvsfwdw
@@ -1,4 +1,11 @@
 #!/bin/bash
+usage () {
+    echo "Usage: $0 [-k] [-q|--enqueue]"
+    echo
+    echo "Options:"
+    echo "  -k: Use KVM for the simulations."
+    echo "  -q, --enqueue: Enqueue the generated simulations to slurm."
+}
 
 SCRIPT_DIR="$(dirname "$(realpath "$0")")"
 SCRIPT_COMMAND="$0"
@@ -13,19 +20,42 @@ CONFIG_FILE="$SCRIPT_DIR/config.chats.fwdrvsfwdw.py"
 GEN_SCRIPTS="$SCRIPT_DIR/../run-scripts/gem5_gen_scripts.py" 
 GEN_SCRIPTS_ARGS=("--config-file" "$CONFIG_FILE")
 
-if [[ "$#" = 1 && ( "$1" = "-q" || "$1" = "--enqueue" )]] ; then
-    GEN_SCRIPTS_ARGS=("${GEN_SCRIPTS_ARGS[@]}" "--enqueue" )
-elif [[ "$#" = 0 ]] ; then
-    : # only generate
-else
-    echo "Only argument supported is -q or --enqueue to enqueue."
-    exit 1
-fi
+while getopts "kq-:" opt; do
+    case "$opt" in
+        -)
+            case "${OPTARG}" in
+                enqueue)
+                    GEN_SCRIPTS_ARGS=("${GEN_SCRIPTS_ARGS[@]}" "--enqueue" )
+                    ;;
+                *)
+                    echo "Invalid option: --$OPTARG" >&2
+                    usage
+                    exit 1
+                    ;;
+            esac
+            ;;
+        q)
+            GEN_SCRIPTS_ARGS=("${GEN_SCRIPTS_ARGS[@]}" "--enqueue" )
+            ;;
+        k)
+            export KVM_ACTIVE="true"
+            ;;
+        *)
+            echo "Invalid option: -$OPTARG" >&2
+            usage
+            exit 1
+            ;;
+    esac
+done
 
+
+# This environment variable is used by $CONFIG_FILE
 export OUTPUT_DIR="${OUTPUT_DIR:-$(realpath "$SCRIPT_DIR/../../../results/chats-fwdrvsfwdw-sens")}"
+
+
 [[ -n "${OUTPUT_DIR:-}" && -e "$OUTPUT_DIR" ]] && {
     echo "Output directory «$OUTPUT_DIR» already exists. Delete it or use another."
     exit 1;
 }
 
-"$GEN_SCRIPTS" "${GEN_SCRIPTS_ARGS[@]}" "$@"
+"$GEN_SCRIPTS" "${GEN_SCRIPTS_ARGS[@]}"

--- a/gem5/gem5_path/scripts/CHATS/generate-simulations-fwdrvsfwdw
+++ b/gem5/gem5_path/scripts/CHATS/generate-simulations-fwdrvsfwdw
@@ -3,7 +3,7 @@ usage () {
     echo "Usage: $0 [-k] [-q|--enqueue]"
     echo
     echo "Options:"
-    echo "  -k: Use KVM for the simulations."
+    echo "  -k: Do NOT use KVM for the simulations."
     echo "  -q, --enqueue: Enqueue the generated simulations to slurm."
 }
 
@@ -19,7 +19,7 @@ CONFIG_FILE="$SCRIPT_DIR/config.chats.fwdrvsfwdw.py"
 
 GEN_SCRIPTS="$SCRIPT_DIR/../run-scripts/gem5_gen_scripts.py" 
 GEN_SCRIPTS_ARGS=("--config-file" "$CONFIG_FILE")
-export KVM_ACTIVE="false"
+export KVM_ACTIVE="true"
 while getopts "kq-:" opt; do
     case "$opt" in
         -)
@@ -38,7 +38,7 @@ while getopts "kq-:" opt; do
             GEN_SCRIPTS_ARGS=("${GEN_SCRIPTS_ARGS[@]}" "--enqueue" )
             ;;
         k)
-            export KVM_ACTIVE="true"
+            export KVM_ACTIVE="false"
             ;;
         *)
             echo "Invalid option: -$OPTARG" >&2

--- a/gem5/gem5_path/scripts/CHATS/generate-simulations-main
+++ b/gem5/gem5_path/scripts/CHATS/generate-simulations-main
@@ -19,7 +19,7 @@ CONFIG_FILE="$SCRIPT_DIR/config.chats.main.py"
 
 GEN_SCRIPTS="$SCRIPT_DIR/../run-scripts/gem5_gen_scripts.py" 
 GEN_SCRIPTS_ARGS=("--config-file" "$CONFIG_FILE")
-
+export KVM_ACTIVE="false"
 while getopts "kq-:" opt; do
     case "$opt" in
         -)

--- a/gem5/gem5_path/scripts/CHATS/generate-simulations-main
+++ b/gem5/gem5_path/scripts/CHATS/generate-simulations-main
@@ -1,4 +1,11 @@
 #!/bin/bash
+usage () {
+    echo "Usage: $0 [-k] [-q|--enqueue]"
+    echo
+    echo "Options:"
+    echo "  -k: Use KVM for the simulations."
+    echo "  -q, --enqueue: Enqueue the generated simulations to slurm."
+}
 
 SCRIPT_DIR="$(dirname "$(realpath "$0")")"
 SCRIPT_COMMAND="$0"
@@ -13,15 +20,36 @@ CONFIG_FILE="$SCRIPT_DIR/config.chats.main.py"
 GEN_SCRIPTS="$SCRIPT_DIR/../run-scripts/gem5_gen_scripts.py" 
 GEN_SCRIPTS_ARGS=("--config-file" "$CONFIG_FILE")
 
-if [[ "$#" = 1 && ( "$1" = "-q" || "$1" = "--enqueue" )]] ; then
-    GEN_SCRIPTS_ARGS=("${GEN_SCRIPTS_ARGS[@]}" "--enqueue" )
-elif [[ "$#" = 0 ]] ; then
-    : # only generate
-else
-    echo "Only argument supported is -q or --enqueue to enqueue."
-    exit 1
-fi
+while getopts "kq-:" opt; do
+    case "$opt" in
+        -)
+            case "${OPTARG}" in
+                enqueue)
+                    GEN_SCRIPTS_ARGS=("${GEN_SCRIPTS_ARGS[@]}" "--enqueue" )
+                    ;;
+                *)
+                    echo "Invalid option: --$OPTARG" >&2
+                    usage
+                    exit 1
+                    ;;
+            esac
+            ;;
+        q)
+            GEN_SCRIPTS_ARGS=("${GEN_SCRIPTS_ARGS[@]}" "--enqueue" )
+            ;;
+        k)
+            export KVM_ACTIVE="true"
+            ;;
+        *)
+            echo "Invalid option: -$OPTARG" >&2
+            usage
+            exit 1
+            ;;
+    esac
+done
 
+
+# This environment variable is used by $CONFIG_FILE
 export OUTPUT_DIR="${OUTPUT_DIR:-$(realpath "$SCRIPT_DIR/../../../results/chats-main")}"
 
 
@@ -30,4 +58,4 @@ export OUTPUT_DIR="${OUTPUT_DIR:-$(realpath "$SCRIPT_DIR/../../../results/chats-
     exit 1;
 }
 
-"$GEN_SCRIPTS" "${GEN_SCRIPTS_ARGS[@]}" "$@"
+"$GEN_SCRIPTS" "${GEN_SCRIPTS_ARGS[@]}"

--- a/gem5/gem5_path/scripts/CHATS/generate-simulations-main
+++ b/gem5/gem5_path/scripts/CHATS/generate-simulations-main
@@ -3,7 +3,7 @@ usage () {
     echo "Usage: $0 [-k] [-q|--enqueue]"
     echo
     echo "Options:"
-    echo "  -k: Use KVM for the simulations."
+    echo "  -k: Do NOT use KVM for the simulations."
     echo "  -q, --enqueue: Enqueue the generated simulations to slurm."
 }
 
@@ -19,7 +19,7 @@ CONFIG_FILE="$SCRIPT_DIR/config.chats.main.py"
 
 GEN_SCRIPTS="$SCRIPT_DIR/../run-scripts/gem5_gen_scripts.py" 
 GEN_SCRIPTS_ARGS=("--config-file" "$CONFIG_FILE")
-export KVM_ACTIVE="false"
+export KVM_ACTIVE="true"
 while getopts "kq-:" opt; do
     case "$opt" in
         -)
@@ -38,7 +38,7 @@ while getopts "kq-:" opt; do
             GEN_SCRIPTS_ARGS=("${GEN_SCRIPTS_ARGS[@]}" "--enqueue" )
             ;;
         k)
-            export KVM_ACTIVE="true"
+            export KVM_ACTIVE="false"
             ;;
         *)
             echo "Invalid option: -$OPTARG" >&2

--- a/gem5/gem5_path/scripts/CHATS/generate-simulations-retry-sens
+++ b/gem5/gem5_path/scripts/CHATS/generate-simulations-retry-sens
@@ -19,7 +19,7 @@ CONFIG_FILE="$SCRIPT_DIR/config.chats.retry.sensibility.py"
 
 GEN_SCRIPTS="$SCRIPT_DIR/../run-scripts/gem5_gen_scripts.py" 
 GEN_SCRIPTS_ARGS=("--config-file" "$CONFIG_FILE")
-
+export KVM_ACTIVE="false"
 while getopts "kq-:" opt; do
     case "$opt" in
         -)

--- a/gem5/gem5_path/scripts/CHATS/generate-simulations-retry-sens
+++ b/gem5/gem5_path/scripts/CHATS/generate-simulations-retry-sens
@@ -3,7 +3,7 @@ usage () {
     echo "Usage: $0 [-k] [-q|--enqueue]"
     echo
     echo "Options:"
-    echo "  -k: Use KVM for the simulations."
+    echo "  -k: Do NOT use KVM for the simulations."
     echo "  -q, --enqueue: Enqueue the generated simulations to slurm."
 }
 
@@ -19,7 +19,7 @@ CONFIG_FILE="$SCRIPT_DIR/config.chats.retry.sensibility.py"
 
 GEN_SCRIPTS="$SCRIPT_DIR/../run-scripts/gem5_gen_scripts.py" 
 GEN_SCRIPTS_ARGS=("--config-file" "$CONFIG_FILE")
-export KVM_ACTIVE="false"
+export KVM_ACTIVE="true"
 while getopts "kq-:" opt; do
     case "$opt" in
         -)
@@ -38,7 +38,7 @@ while getopts "kq-:" opt; do
             GEN_SCRIPTS_ARGS=("${GEN_SCRIPTS_ARGS[@]}" "--enqueue" )
             ;;
         k)
-            export KVM_ACTIVE="true"
+            export KVM_ACTIVE="false"
             ;;
         *)
             echo "Invalid option: -$OPTARG" >&2

--- a/gem5/gem5_path/scripts/CHATS/generate-simulations-retry-sens
+++ b/gem5/gem5_path/scripts/CHATS/generate-simulations-retry-sens
@@ -1,4 +1,11 @@
 #!/bin/bash
+usage () {
+    echo "Usage: $0 [-k] [-q|--enqueue]"
+    echo
+    echo "Options:"
+    echo "  -k: Use KVM for the simulations."
+    echo "  -q, --enqueue: Enqueue the generated simulations to slurm."
+}
 
 SCRIPT_DIR="$(dirname "$(realpath "$0")")"
 SCRIPT_COMMAND="$0"
@@ -9,24 +16,46 @@ trap 'echo "$SCRIPT_COMMAND: error $? at line $LINENO"' ERR
 
 CONFIG_FILE="$SCRIPT_DIR/config.chats.retry.sensibility.py"
 
+
 GEN_SCRIPTS="$SCRIPT_DIR/../run-scripts/gem5_gen_scripts.py" 
 GEN_SCRIPTS_ARGS=("--config-file" "$CONFIG_FILE")
 
-if [[ "$#" = 1 && ( "$1" = "-q" || "$1" = "--enqueue" )]] ; then
-    GEN_SCRIPTS_ARGS=("${GEN_SCRIPTS_ARGS[@]}" "--enqueue" )
-elif [[ "$#" = 0 ]] ; then
-    : # only generate
-else
-    echo "Only argument supported is -q or --enqueue to enqueue."
-    exit 1
-fi
+while getopts "kq-:" opt; do
+    case "$opt" in
+        -)
+            case "${OPTARG}" in
+                enqueue)
+                    GEN_SCRIPTS_ARGS=("${GEN_SCRIPTS_ARGS[@]}" "--enqueue" )
+                    ;;
+                *)
+                    echo "Invalid option: --$OPTARG" >&2
+                    usage
+                    exit 1
+                    ;;
+            esac
+            ;;
+        q)
+            GEN_SCRIPTS_ARGS=("${GEN_SCRIPTS_ARGS[@]}" "--enqueue" )
+            ;;
+        k)
+            export KVM_ACTIVE="true"
+            ;;
+        *)
+            echo "Invalid option: -$OPTARG" >&2
+            usage
+            exit 1
+            ;;
+    esac
+done
+
 
 # This environment variable is used by $CONFIG_FILE
 export OUTPUT_DIR="${OUTPUT_DIR:-$(realpath "$SCRIPT_DIR/../../../results/chats-retry-sens")}"
+
 
 [[ -n "${OUTPUT_DIR:-}" && -e "$OUTPUT_DIR" ]] && {
     echo "Output directory «$OUTPUT_DIR» already exists. Delete it or use another."
     exit 1;
 }
 
-"$GEN_SCRIPTS" "${GEN_SCRIPTS_ARGS[@]}" "$@"
+"$GEN_SCRIPTS" "${GEN_SCRIPTS_ARGS[@]}"

--- a/generators/Makefile
+++ b/generators/Makefile
@@ -16,10 +16,9 @@ generate_compose:
 		-w "$(MAX_IO_PER_CONTAINER)" \
 		$(KVM_FLAG)
 
-generate-kvm: KVM_FLAG = "-k"
-generate_kvm: generate_slurm generate_compose
+generate: generate_slurm generate_compose
 	@echo "All configuration files generated!"
 
-generate-atomic: KVM_FLAG = ""
-generate_atomic: generate_slurm generate_compose
-	@echo "All configuration files generated!"
+generate_kvm: KVM_FLAG = "-k" generate
+
+generate_atomic: KVM_FLAG = "" generate

--- a/generators/Makefile
+++ b/generators/Makefile
@@ -16,7 +16,7 @@ generate_compose:
 		-w "$(MAX_IO_PER_CONTAINER)" \
 		$(KVM_FLAG)
 
-generate: generate_slurm generate_compose
+generate_kvm generate_atomic: generate_slurm generate_compose
 	@echo "All configuration files generated!"
 
 generate_kvm: KVM_FLAG = "-k" generate

--- a/generators/Makefile
+++ b/generators/Makefile
@@ -1,4 +1,3 @@
-KVM_FLAG = ""
 generate_slurm:
 	@echo "Generating slurm configuration files"
 	@echo "Using $(M_NUM_CPUS) CPUs. If you want to " \
@@ -17,10 +16,10 @@ generate_compose:
 		-w "$(MAX_IO_PER_CONTAINER)" \
 		$(KVM_FLAG)
 
-
+generate-kvm: KVM_FLAG = "-k"
 generate_kvm: generate_slurm generate_compose
-	KVM_FLAG = "-k"
 	@echo "All configuration files generated!"
 
+generate-atomic: KVM_FLAG = ""
 generate_atomic: generate_slurm generate_compose
 	@echo "All configuration files generated!"

--- a/generators/Makefile
+++ b/generators/Makefile
@@ -1,3 +1,4 @@
+KVM_FLAG = ""
 generate_slurm:
 	@echo "Generating slurm configuration files"
 	@echo "Using $(M_NUM_CPUS) CPUs. If you want to " \
@@ -13,8 +14,13 @@ generate_compose:
 		"variable from Makefile."
 	@./generate_docker_compose.sh -n $(M_NUM_SERVICES) \
 		-d $(M_CURRENT_DEVICE) \
-		-w "$(MAX_IO_PER_CONTAINER)"
+		-w "$(MAX_IO_PER_CONTAINER)" \
+		$(KVM_FLAG)
 
 
-generate: generate_slurm generate_compose
+generate_kvm: generate_slurm generate_compose
+	KVM_FLAG = "-k"
+	@echo "All configuration files generated!"
+
+generate_atomic: generate_slurm generate_compose
 	@echo "All configuration files generated!"

--- a/slurm-docker-cluster/Dockerfile
+++ b/slurm-docker-cluster/Dockerfile
@@ -30,7 +30,6 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt -y update && apt -y upgrade && \
         apt -y install \
         build-essential \
-        git \
         m4 \
         scons \
         zlib1g \
@@ -39,7 +38,6 @@ RUN apt -y update && apt -y upgrade && \
         protobuf-compiler \
         libprotoc-dev \
         libgoogle-perftools-dev \
-        python3-dev \
         python-is-python3 \
         doxygen \
         libboost-all-dev \

--- a/templates/docker-compose.yml.template
+++ b/templates/docker-compose.yml.template
@@ -46,8 +46,7 @@ services:
       - gem5_path:/gem5
       - ./gem5/dockerfiles/modules:/lib/modules:ro
       - ./results:/gem5/results
-    devices:
-      - "/dev/kvm:/dev/kvm"
+    DEVICES_KVM
     expose:
       - "6817"
     depends_on:

--- a/templates/service_component.template
+++ b/templates/service_component.template
@@ -14,8 +14,7 @@
       - gem5_path:/gem5
       - ./gem5/dockerfiles/modules:/lib/modules:ro
       - ./results:/gem5/results
-    devices:
-      - "/dev/kvm:/dev/kvm"
+    DEVICES_KVM
     expose:
       - "6818"
     deploy:


### PR DESCRIPTION
Add an atomicCPU fast-forward option. Changes to build, makefiles and scripts to allow to choose between kvm and atomic cpu. To build to use atomic, execute make build_atomic. NOTE: it is recommended to use kvm as atomicCPU can severely increase the amount of time spent to reach the ROI and checkpoint.